### PR TITLE
Add .claude/settings.json: read-only GitHub + git + PR-activity

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,32 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__Claude_Code_Remote__subscribe_pr_activity",
+      "mcp__Claude_Code_Remote__unsubscribe_pr_activity",
+      "mcp__github__actions_get",
+      "mcp__github__actions_list",
+      "mcp__github__get_job_logs",
+      "mcp__github__get_check_run",
+      "mcp__github__pull_request_read",
+      "mcp__github__list_pull_requests",
+      "mcp__github__search_pull_requests",
+      "mcp__github__get_commit",
+      "mcp__github__list_commits",
+      "mcp__github__list_branches",
+      "mcp__github__list_tags",
+      "mcp__github__get_file_contents",
+      "mcp__github__issue_read",
+      "mcp__github__list_issues",
+      "mcp__github__search_issues",
+      "mcp__github__search_code",
+      "mcp__github__get_me",
+      "mcp__github__get_latest_release",
+      "mcp__github__list_releases",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git fetch:*)"
+    ]
+  }
+}


### PR DESCRIPTION
Part of a consistent `.claude/settings.json` allow-list across the bldrs repos so the assistant's PR-babysitting + review workflow stops prompting on safe, read-only actions.

- **PR activity**: `subscribe_pr_activity` / `unsubscribe_pr_activity`
- **Read-only GitHub MCP**: PR / CI / commit / branch / tag / issue / release / code-search reads
- **Read-only git**: `status`, `diff`, `log`, `show`, `fetch`

This is a data repo (no build/test scripts), so no dev-loop commands are allow-listed. Every mutating action still prompts: opening / merging PRs, commenting, pushing, and any other Bash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7)_